### PR TITLE
Fix issue where user key saved to key of same value

### DIFF
--- a/AdzerkSDK/AdzerkSDK/ADZKeychainUserKeyStore.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZKeychainUserKeyStore.swift
@@ -34,7 +34,7 @@ import Foundation
     */
     public func saveUserKey(key: String) {
         let data = key.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
-        ADZKeychainHelper.save(key, data: data)
+        ADZKeychainHelper.save(adzUserKey, data: data)
     }
     
     /** 


### PR DESCRIPTION
The user key was being saved to a key that was the text of the user key
instead of adzUserKey. This caused the user key to essentially be lost
every time, a new key being generated, and then saved to a completely
different key in the keychain. Everything pulled out of adzUserKey
would always be nil.