### PR TITLE
Swift 3 conversion for the workspace.

### DIFF
--- a/AdzerkSDK/AdzerkSDK.xcodeproj/project.pbxproj
+++ b/AdzerkSDK/AdzerkSDK.xcodeproj/project.pbxproj
@@ -32,8 +32,8 @@
 		B5DB643F1B7E434F00A243AC /* ADZFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB643C1B7E3E5F00A243AC /* ADZFunctions.swift */; };
 		B5DB64411B7E457400A243AC /* ADZPlacementDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB64401B7E457400A243AC /* ADZPlacementDecision.swift */; };
 		B5DB64421B7E458200A243AC /* ADZPlacementDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB64401B7E457400A243AC /* ADZPlacementDecision.swift */; };
-		B5F8548F1BA32DEA000F1F02 /* ADZUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8548E1BA32DEA000F1F02 /* ADZUser.swift */; settings = {ASSET_TAGS = (); }; };
-		B5F854901BA3328F000F1F02 /* ADZUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8548E1BA32DEA000F1F02 /* ADZUser.swift */; settings = {ASSET_TAGS = (); }; };
+		B5F8548F1BA32DEA000F1F02 /* ADZUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8548E1BA32DEA000F1F02 /* ADZUser.swift */; };
+		B5F854901BA3328F000F1F02 /* ADZUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8548E1BA32DEA000F1F02 /* ADZUser.swift */; };
 		B5FBCAC91B961FEE007F2E64 /* ADZResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B502CB041B95E76E0091277C /* ADZResponse.swift */; };
 		B5FBCACA1B974620007F2E64 /* ADZPlacementRequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B503D1881B7CF967008C0C8A /* ADZPlacementRequestOptions.swift */; };
 		B5FBCACB1B974620007F2E64 /* ADZPlacementRequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B503D1881B7CF967008C0C8A /* ADZPlacementRequestOptions.swift */; };
@@ -222,9 +222,12 @@
 				TargetAttributes = {
 					B5C89DC51B78EBB3003CA162 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
 					};
 					B5C89DD01B78EBB3003CA162 = {
 						CreatedOnToolsVersion = 6.4;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -360,6 +363,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -400,6 +404,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -411,7 +416,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -422,6 +429,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -429,7 +437,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -439,12 +449,15 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adzerk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};
 		B5C89DE01B78EBB3003CA162 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -453,16 +466,20 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adzerk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
 		B5C89DE11B78EBB3003CA162 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = AdzerkSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adzerk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};

--- a/AdzerkSDK/AdzerkSDK/ADZFunctions.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZFunctions.swift
@@ -10,17 +10,17 @@ import Foundation
 
 
 // return a new array with optionals removed, change type to !
-func compact<T>(source: [T?]) -> [T] {
+func compact<T>(_ source: [T?]) -> [T] {
     return source.filter { $0 != nil }.map { $0! }
 }
 
 // Swift 1.2's flatMap doesn't work with optionals. Can remove when on Swift 2 and replace with plain flatMap :)
 // filterMap removes optionals, then applies the transform
-func filterMap<T, U>(source: [T?], transform: T -> U ) -> [U] {
+func filterMap<T, U>(_ source: [T?], transform: (T) -> U ) -> [U] {
     return compact(source).map(transform)
 }
 
-func groupBy<T, K: Hashable>(source: [T], keyMethod: T -> K) -> [K: T] {
+func groupBy<T, K: Hashable>(_ source: [T], keyMethod: (T) -> K) -> [K: T] {
     var dict = [K: T]()
     for item in source {
         let key = keyMethod(item)

--- a/AdzerkSDK/AdzerkSDK/ADZKeychainHelper.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZKeychainHelper.swift
@@ -17,12 +17,12 @@ class ADZKeychainHelper {
         @param data the data to save
         @returns true if the value was set successfully
     */
-    class func save(key: String, data: NSData) -> Bool {
+    class func save(_ key: String, data: Data) -> Bool {
         let query = [
             (kSecClass as String) : (kSecClassGenericPassword as String),
             (kSecAttrAccount as String) : key,
             (kSecValueData as String) : data
-        ] as CFDictionaryRef
+        ] as CFDictionary
 
         // remove item if it exists already
         SecItemDelete(query)
@@ -38,29 +38,29 @@ class ADZKeychainHelper {
         @param key the identifier the data was originally saved with
         @returns the saved data, or nil if nothing was saved for this key
     */
-    class func fetch(key: String) -> NSData? {
+    class func fetch(_ key: String) -> Data? {
         let query = [
             (kSecClass as String) : (kSecClassGenericPassword as String),
             (kSecAttrAccount as String) : key,
             (kSecReturnData as String) : kCFBooleanTrue,
             (kSecMatchLimit as String) : kSecMatchLimitOne
-        ] as CFDictionaryRef
+        ] as CFDictionary
 
         var keychainData: AnyObject?
         let status: OSStatus = SecItemCopyMatching(query, &keychainData)
         if status == noErr {
-            return keychainData as? NSData
+            return keychainData as? Data
         } else {
             return nil
         }
     }
 
-    class func delete(key: String) {
+    class func delete(_ key: String) {
         let query = [
             (kSecClass as String) : (kSecClassGenericPassword as String),
             (kSecAttrAccount as String) : key
         ]
-        SecItemDelete(query)
+        SecItemDelete(query as CFDictionary)
     }
 }
 

--- a/AdzerkSDK/AdzerkSDK/ADZKeychainUserKeyStore.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZKeychainUserKeyStore.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
     Provides secure storage for the User key via the iOS Keychain. This is the default implementation of `ADZUserKeyStore`.
 */
-@objc public class ADZKeychainUserKeyStore : NSObject, ADZUserKeyStore {
+@objc open class ADZKeychainUserKeyStore : NSObject, ADZUserKeyStore {
     let adzUserKey = "ADZUserKey"
     
     /** 
@@ -19,9 +19,9 @@ import Foundation
     
         - returns: the user key, or nil if none exists
     */
-    public func currentUserKey() -> String? {
+    open func currentUserKey() -> String? {
         if let data = ADZKeychainHelper.fetch(adzUserKey) {
-            return NSString(data: data, encoding: NSUTF8StringEncoding) as? String
+            return String(data: data as Data, encoding: String.Encoding.utf8)
         }
         
         return nil
@@ -32,15 +32,15 @@ import Foundation
     
         - parameter key: the user key to save
     */
-    public func saveUserKey(key: String) {
-        let data = key.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
-        ADZKeychainHelper.save(adzUserKey, data: data)
+    open func saveUserKey(_ key: String) {
+        let data = key.data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        let _ = ADZKeychainHelper.save(adzUserKey, data: data)
     }
     
     /** 
         Removes the userKey from the keychain.
     */
-    public func removeUserKey() {
+    open func removeUserKey() {
         ADZKeychainHelper.delete(adzUserKey)
     }
     

--- a/AdzerkSDK/AdzerkSDK/ADZPlacement.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacement.swift
@@ -9,27 +9,27 @@
 import Foundation
 
 /** Specifies a placement's details to request. */
-@objc public class ADZPlacement : NSObject {
+@objc open class ADZPlacement : NSObject {
     
     /** The name of the div */
-    public let divName: String
+    open let divName: String
     
     /** The network ID. If none is specified it retrieves the value from `AdzerkSDK.defaultNetworkId` */
-    public let networkId: Int
+    open let networkId: Int
     
     /** The site ID. If none is specified it retrieves the value from `AdzerkSDK.defaultSiteId` */
-    public let siteId: Int
+    open let siteId: Int
     
     /** An array of integers representing the ad types to request. The full list can be found at https://github.com/adzerk/adzerk-api/wiki/Ad-Types . */
-    public let adTypes: [Int]
+    open let adTypes: [Int]
     
-    public var zoneIds: [Int]?
-    public var eventIds: [Int]?
+    open var zoneIds: [Int]?
+    open var eventIds: [Int]?
     
-    public var properties: [String: AnyObject]?
-    public var campaignId: Int?
-    public var flightId: Int?
-    public var adId: Int?
+    open var properties: [String: Any]?
+    open var campaignId: Int?
+    open var flightId: Int?
+    open var adId: Int?
     
     public init(divName: String, networkId: Int, siteId: Int, adTypes: [Int]) {
         self.divName = divName
@@ -40,7 +40,7 @@ import Foundation
     }
     
     public convenience init?(divName: String, adTypes: [Int]) {
-        if let networkId = AdzerkSDK.defaultNetworkId, siteId = AdzerkSDK.defaultSiteId {
+        if let networkId = AdzerkSDK.defaultNetworkId, let siteId = AdzerkSDK.defaultSiteId {
             self.init(divName: divName, networkId: networkId, siteId: siteId, adTypes: adTypes)
         } else {
             print("Warning: Using this initializer requires AdzerkSDK.defaultNetworkId and Adzerk.defaultSiteId to be defined")
@@ -49,8 +49,8 @@ import Foundation
         }
     }
     
-    func serialize() -> [String : AnyObject] {
-        var json: [String: AnyObject] = [
+    func serialize() -> [String : Any] {
+        var json: [String: Any] = [
                 "divName"  : divName,
                 "networkId": networkId,
                 "siteId"   : siteId,

--- a/AdzerkSDK/AdzerkSDK/ADZPlacementContent.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementContent.swift
@@ -15,29 +15,29 @@ import Foundation
     This would be represented as two contents, one with the type `css` and one 
     with the type `html`.
 */
-public class ADZPlacementContent {
+open class ADZPlacementContent {
     /** 
         Indicates the type of content.
         Examples: `css`, `html`, `js`, `js-external`, or `raw`.
     */
-    public let type: String?
+    open let type: String?
     
     /* If the content uses a predefined template, this will be set to the name of the template. */
-    public let template: String?
+    open let template: String?
     
     /* Contains the template data used to build the content. */
-    public let data: [String: AnyObject]?
+    open let data: [String: Any]?
     
     /* The rendered body of the content. */
-    public let body: String?
+    open let body: String?
     
     /**
         Initializes the struct from a JSON dictionary (expects keys: `type`, `template`, `data`, `body`, and `customData`) 
     */
-    public init(dictionary: [String: AnyObject]) {
+    public init(dictionary: [String: Any]) {
         type = dictionary["type"] as? String
         template = dictionary["template"] as? String
-        data = dictionary["data"] as? [String: AnyObject]
+        data = dictionary["data"] as? [String: Any]
         body = dictionary["body"] as? String
     }
 }

--- a/AdzerkSDK/AdzerkSDK/ADZPlacementDecision.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementDecision.swift
@@ -12,39 +12,38 @@ import Foundation
     Response structure for decisions, found in a placement response. Each decision
     will be represented as one of these.
 */
-public class ADZPlacementDecision {
+open class ADZPlacementDecision {
     /** The name of the div requested */
-    public let divName: String
+    open let divName: String
     
-    public let adId: Int?
-    public let creativeId: Int?
-    public let flightId: Int?
-    public let campaignId: Int?
-    public let clickUrl: String?
-    public let impressionUrl: String?
+    open let adId: Int?
+    open let creativeId: Int?
+    open let flightId: Int?
+    open let campaignId: Int?
+    open let clickUrl: String?
+    open let impressionUrl: String?
     
     /** An array of `ADZPlacementContent`, representing the actual contents
         to display for this decision, if there are any.
     */
-    public let contents: [ADZPlacementContent]?
+    open let contents: [ADZPlacementContent]?
     
     /** An array of `ADZPlacementEvent`, representing the events for this decision,
         if there are any. */
-    public let events: [ADZPlacementEvent]?
+    open let events: [ADZPlacementEvent]?
     
     /** All of the attributes will be present in this dictionary,
         in case there are additional attributes being sent that are not modeled
         as properties.
     */
-    public let allAttributes: [String: AnyObject]?
+    open let allAttributes: [String: Any]?
     
     /** Initializes the struct based on a JSON dictionary.
         @param name The name of the div for this decision
         @param JSON dictionary of attributes returned from the server
         @returns an initialized struct, or nil if the response format was not recognized
     */
-    public init?(name: String, dictionary: [String: AnyObject]?) {
-        print(dictionary)
+    public init?(name: String, dictionary: [String: Any]?) {
         divName = name
         allAttributes = dictionary
         adId = dictionary?["adId"] as? Int

--- a/AdzerkSDK/AdzerkSDK/ADZPlacementEvent.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementEvent.swift
@@ -11,7 +11,7 @@ import Foundation
 /** 
     Returns tracking URLs for any requested custom events.
 */
-public class ADZPlacementEvent {
+open class ADZPlacementEvent {
     let id: Int
     let url: String
     

--- a/AdzerkSDK/AdzerkSDK/ADZPlacementRequestOptions.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementRequestOptions.swift
@@ -9,19 +9,19 @@
 import Foundation
 
 /** Provides a mechanism for adding top-level metadata to the placement request. */
-public class ADZPlacementRequestOptions: NSObject {
-    public var keywords: [String]?
-    public var blockedCreatives: [Int]?
-    public var flightViewTimes: [String: [Int]]?
-    public var url: String?
+open class ADZPlacementRequestOptions: NSObject {
+    open var keywords: [String]?
+    open var blockedCreatives: [Int]?
+    open var flightViewTimes: [String: [Int]]?
+    open var url: String?
     
     /** The user key for this request. If nil, the current saved user key will be used from
         the configured `ADZUserKeyStore` on `AdzerkSDK`.
     */
-    public var userKey: String?
+    open var userKey: String?
     
     /** Any additional parameters can be provided here and will be added to the request */
-    public var additionalOptions: [String: AnyObject]?
+    open var additionalOptions: [String: AnyObject]?
     
     public override init() {
     }

--- a/AdzerkSDK/AdzerkSDK/ADZPlacementResponse.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementResponse.swift
@@ -12,9 +12,9 @@ import Foundation
     Top level response object for placement requests.
     Documentation can be found at: http://help.adzerk.com/hc/en-us/articles/203193935-Response
 */
-public class ADZPlacementResponse: NSObject {
-    public let decisions: [String: ADZPlacementDecision]
-    public let extraAttributes: [String: AnyObject]
+open class ADZPlacementResponse: NSObject {
+    open let decisions: [String: ADZPlacementDecision]
+    open let extraAttributes: [String: AnyObject]
     
     init?(dictionary: [String: AnyObject]) {
         if let decisionsDict = dictionary["decisions"] as? [String: AnyObject] {

--- a/AdzerkSDK/AdzerkSDK/ADZResponse.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZResponse.swift
@@ -11,14 +11,14 @@ import Foundation
 /** Models the various types of responses you can receive from the API. */
 public enum ADZResponse {
     /** Indicates a successful response. Includes the placements requested. */
-    case Success(ADZPlacementResponse)
+    case success(ADZPlacementResponse)
     
     /** Indicates something was wrong with the request. Includes the HTTP status code and the response body. */
-    case BadRequest(Int, String)
+    case badRequest(Int, String)
     
     /** Indicates the response was not recognized (valid JSON). Includes the response body. */
-    case BadResponse(String)
+    case badResponse(String)
     
     /** Indicates that the request was not completed. This can happen due to lack of network connectivity, redirect loops, timeouts, and other factors. */
-    case Error(NSError)
+    case error(Error)
 }

--- a/AdzerkSDK/AdzerkSDK/ADZUser.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZUser.swift
@@ -12,20 +12,20 @@ import Foundation
     Contains the information known about a user in UserDB. Returned
     by calling `readUser` on `AdzerSDK`.
 */
-@objc public class ADZUser : NSObject {
-    public let userKey: String!
-    public let blockedItems: [String: AnyObject]!
-    public let interests: [String]!
-    public let customProperties: [String: AnyObject]!
-    public let optOut: Bool
+@objc open class ADZUser : NSObject {
+    open let userKey: String!
+    open let blockedItems: [String: AnyObject]!
+    open let interests: [String]!
+    open let customProperties: [String: AnyObject]!
+    open let optOut: Bool
     
     init?(dictionary: [String: AnyObject]) {
         guard let
             key = dictionary["key"] as? String,
-            blockedItems = dictionary["blockedItems"] as? [String: AnyObject],
-            interests = dictionary["interests"] as? [String],
-            customProperties = dictionary["custom"] as? [String: AnyObject],
-            optOut = dictionary["optOut"] as? NSNumber
+            let blockedItems = dictionary["blockedItems"] as? [String: AnyObject],
+            let interests = dictionary["interests"] as? [String],
+            let customProperties = dictionary["custom"] as? [String: AnyObject],
+            let optOut = dictionary["optOut"] as? NSNumber
         
             else {
                 self.userKey = ""

--- a/AdzerkSDK/AdzerkSDK/ADZUserKeyStore.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZUserKeyStore.swift
@@ -23,7 +23,7 @@ import Foundation
     func currentUserKey() -> String?
 
     /** Saves a key for the current user. */
-    func saveUserKey(key: String)
+    func saveUserKey(_ key: String)
     
     /** Removes a saved user key. */
     func removeUserKey()

--- a/AdzerkSDK/AdzerkSDKTests/FakeKeyStore.swift
+++ b/AdzerkSDK/AdzerkSDKTests/FakeKeyStore.swift
@@ -11,7 +11,7 @@ import Foundation
 @objc class FakeKeyStore : NSObject, ADZUserKeyStore {
     var key: String?
     
-    func saveUserKey(key: String) {
+    func saveUserKey(_ key: String) {
         self.key = key
     }
     

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 				TargetAttributes = {
 					B5C89DEA1B78ECF0003CA162 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0810;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -276,10 +278,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SampleApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adzerk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -287,10 +292,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SampleApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adzerk.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SampleApp/SampleApp/AppDelegate.swift
+++ b/SampleApp/SampleApp/AppDelegate.swift
@@ -17,31 +17,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let networkId = 9792
     let siteId = 306998
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         AdzerkSDK.defaultNetworkId = networkId
         AdzerkSDK.defaultSiteId = siteId
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/SampleApp/SampleApp/Functions.swift
+++ b/SampleApp/SampleApp/Functions.swift
@@ -11,17 +11,21 @@ import Foundation
 
 extension Array {
     // borrowed from haskell, group array into subgroups of n elements
-    func splitEvery(n: Int) -> [[Element]] {
+    func splitEvery(_ n: Int) -> [[Element]] {
         var result = [[Element]]()
         
         var group = [Element]()
         var counter = 0
         for item in self {
             group.append(item)
-            if counter++ > n {
+            
+            if counter > n {
                 counter = 0
                 result.append(group)
                 group = []
+            }
+            else {
+                counter += 1
             }
         }
 
@@ -30,9 +34,9 @@ extension Array {
 }
 
 // Interleave B into A every N elements
-func interleave<A, B>(a: [A], _ b: [B], every n: Int) -> [Any] {
+func interleave<A, B>(_ a: [A], _ b: [B], every n: Int) -> [Any] {
     var result = [Any]()
-    var bSequence = b.generate()
+    var bSequence = b.makeIterator()
     let chunkedAs = a.splitEvery(n)
     for group in chunkedAs {
         for item in group {

--- a/SampleApp/SampleApp/ImageViewExtension.swift
+++ b/SampleApp/SampleApp/ImageViewExtension.swift
@@ -9,24 +9,24 @@
 import UIKit
 
 class RemoteImageView: UIImageView {
-    var task: NSURLSessionDataTask? = nil
+    var task: URLSessionDataTask? = nil
     
-    func loadImageWithURL(url: NSURL) {
+    func loadImageWithURL(_ url: URL) {
         if let task = task {
             task.cancel()
         }
         
         image = nil
-        task = NSURLSession.sharedSession().dataTaskWithURL(url) { (data, response, error) in
+        task = URLSession.shared.dataTask(with: url, completionHandler: { (data, response, error) in
             if error == nil {
-                if self.task?.state == NSURLSessionTaskState.Canceling {
+                if self.task?.state == URLSessionTask.State.canceling {
                     return
                 }
-                let http = response as! NSHTTPURLResponse
+                let http = response as! HTTPURLResponse
                 if http.statusCode == 200 {
                     let image = UIImage(data: data!)
-                    dispatch_async(dispatch_get_main_queue()) {
-                        if self.task?.state == NSURLSessionTaskState.Canceling {
+                    DispatchQueue.main.async {
+                        if self.task?.state == URLSessionTask.State.canceling {
                             return
                         }
                         
@@ -38,7 +38,7 @@ class RemoteImageView: UIImageView {
             } else {
                 // ignore
             }
-        }
+        }) 
         task?.resume()
     }
 }

--- a/SampleApp/SampleApp/VikingGenerator.swift
+++ b/SampleApp/SampleApp/VikingGenerator.swift
@@ -11,12 +11,12 @@ import Foundation
 struct Viking {
     let name: String
     let quote: String
-    let imageUrl: NSURL
+    let imageUrl: URL
 }
 
 // Taken from the Android sample app.
 class VikingGenerator {
-    static func generateVikings(count: Int) -> [Viking] {
+    static func generateVikings(_ count: Int) -> [Viking] {
         var vikings: [Viking] = []
         
         for _ in 0..<count {
@@ -85,13 +85,13 @@ class VikingGenerator {
         return quotes[randomInt(quotes.count)]
     }
     
-    static func randomHeadshot() -> NSURL {
+    static func randomHeadshot() -> URL {
         let max = 88;
         let urlString = "http://api.randomuser.me/portraits/med/women/\(randomInt(max)).jpg"
-        return NSURL(string: urlString)!
+        return URL(string: urlString)!
     }
     
-    static func randomInt(max: Int) -> Int {
+    static func randomInt(_ max: Int) -> Int {
         return Int(arc4random_uniform(UInt32(max)))
     }
 }

--- a/SampleApp/SampleApp/VikingsTableViewController.swift
+++ b/SampleApp/SampleApp/VikingsTableViewController.swift
@@ -21,7 +21,7 @@ class VikingsTableViewController : UITableViewController {
     // record of impressions sent
     var impressions: [String: Bool] = [:]
     
-    private var _rowData: [Any]?
+    fileprivate var _rowData: [Any]?
     var rowData: [Any]! {
         if _rowData == nil {
             _rowData = interleave(vikings, decisions, every: 10)
@@ -43,18 +43,18 @@ class VikingsTableViewController : UITableViewController {
         }
     }
     
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return rowData.count
     }
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let obj = rowData[indexPath.row]
         if let viking = obj as? Viking {
-            let cell = tableView.dequeueReusableCellWithIdentifier("VikingCell") as! VikingCell
+            let cell = tableView.dequeueReusableCell(withIdentifier: "VikingCell") as! VikingCell
             configureVikingCell(cell, viking: viking)
             return cell
         } else if let decision = obj as? ADZPlacementDecision {
-            let cell = tableView.dequeueReusableCellWithIdentifier("DecisionCell") as! DecisionCell
+            let cell = tableView.dequeueReusableCell(withIdentifier: "DecisionCell") as! DecisionCell
             configureDecisionCell(cell, decision: decision)
             return cell
         } else {
@@ -62,9 +62,9 @@ class VikingsTableViewController : UITableViewController {
         }
     }
     
-    override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let _ = cell as? DecisionCell {
-            if let decision = rowData[indexPath.row] as? ADZPlacementDecision, impressionUrl = decision.impressionUrl {
+            if let decision = rowData[indexPath.row] as? ADZPlacementDecision, let impressionUrl = decision.impressionUrl {
                 if impressions[impressionUrl] == nil {
                     impressions[impressionUrl] = true
                     recordImpression(impressionUrl)
@@ -73,8 +73,8 @@ class VikingsTableViewController : UITableViewController {
         }
     }
     
-    private func recordImpression(urlString: String) {
-        if let url = NSURL(string: urlString) {
+    fileprivate func recordImpression(_ urlString: String) {
+        if let url = URL(string: urlString) {
             print("Recording impression for \(url)")
             adzerkSDK.recordImpression(url)
         } else {
@@ -82,7 +82,7 @@ class VikingsTableViewController : UITableViewController {
         }
     }
     
-    private func loadPlacements(completion: () -> ()) {
+    fileprivate func loadPlacements(_ completion: @escaping () -> ()) {
         
         let options = ADZPlacementRequestOptions()
         options.keywords = ["karate", "kittens", "knives"]
@@ -93,45 +93,45 @@ class VikingsTableViewController : UITableViewController {
         
         adzerkSDK.requestPlacements([placement], options: options) { response in
             switch response {
-            case .Success(let placementResponse):
+            case .success(let placementResponse):
                 self.decisions = Array(placementResponse.decisions.values)
                 print("Decisions: \(self.decisions)")
                 break
                 
-            case .BadRequest(let status, let body):
+            case .badRequest(let status, let body):
                 print("Bad request: HTTP \(status) -> \(body)")
                 
-            case .BadResponse(let body):
+            case .badResponse(let body):
                 print("Bad response: \(body)")
                 
-            case .Error(let error):
+            case .error(let error):
                 print("error fetching placements: \(error)")
             }
             
-            dispatch_async(dispatch_get_main_queue(), completion)
+            DispatchQueue.main.async(execute: completion)
         }
     }
     
-    private func loadVikings() {
+    fileprivate func loadVikings() {
         vikings = VikingGenerator.generateVikings(40)
     }
     
-    private func configureVikingCell(cell: VikingCell, viking: Viking) {
+    fileprivate func configureVikingCell(_ cell: VikingCell, viking: Viking) {
         cell.nameLabel.text = viking.name
         cell.quoteLabel.text = viking.quote
         cell.vikingImageView.loadImageWithURL(viking.imageUrl)
     }
     
-    private func configureDecisionCell(cell: DecisionCell, decision: ADZPlacementDecision) {
-        if let contents = decision.contents?.first, data = contents.data {
+    fileprivate func configureDecisionCell(_ cell: DecisionCell, decision: ADZPlacementDecision) {
+        if let contents = decision.contents?.first, let data = contents.data {
             if let title = data["title"] as? String {
                 cell.nameLabel.text = title
             }
-            if let customData = data["customData"] as? [String: String], quote = customData["quote"] {
+            if let customData = data["customData"] as? [String: String], let quote = customData["quote"] {
                 cell.quoteLabel.text = quote
             }
             if let imageUrl = data["imageUrl"] as? String {
-                let url = NSURL(string: imageUrl)!
+                let url = URL(string: imageUrl)!
                 cell.vikingImageView.loadImageWithURL(url)
             }
         } else {


### PR DESCRIPTION
Converted the SDK, sample app and tests to Swift 3 syntax.

I tested that the sample app worked OK and also ran the SDK tests. Only test that failed was:

AdzerkSDKTests.testCanRequestPlacementwithAllParameters() (row 191)

I suspect this is not due to the swift 3 conversion, as I checked the raw decision response string and it did not contain the wanted property (content.template!). So that is probably something with the request params / ad setup rather than a SDK problem.