### PR TITLE
Open (make public) the properties of ADZPlacementEvent class.

### DIFF
--- a/AdzerkSDK/AdzerkSDK/ADZPlacementEvent.swift
+++ b/AdzerkSDK/AdzerkSDK/ADZPlacementEvent.swift
@@ -12,8 +12,8 @@ import Foundation
     Returns tracking URLs for any requested custom events.
 */
 open class ADZPlacementEvent {
-    let id: Int
-    let url: String
+    open let id: Int
+    open let url: String
     
     /** Initialize a new struct given a JSON dictionary. Expects the keys `id` and `url` 
         to be present in the dictionary.


### PR DESCRIPTION
This is required to use events when using AdzerkSDK from a separate module (e.g. as a CocoaPod). Without this the id and url properties are visible only inside the AdzerkSDK module.