### PR TITLE
2.0 interest and retargeting

### DIFF
--- a/Sources/AdzerkSDK/UserDB.swift
+++ b/Sources/AdzerkSDK/UserDB.swift
@@ -88,6 +88,18 @@ public class UserDB {
     }
     
     public func optOut(completion: @escaping (Result<Void, AdzerkError>) -> Void) {
+        pixelRequest(endpoint: "optOut/i.gif", completion: completion)
+    }
+    
+    public func addInterest(_ interest: String, completion: @escaping (Result<Void, AdzerkError>) -> Void) {
+        pixelRequest(endpoint: "interest/i.gif", params: ["interest": interest], completion: completion)
+    }
+    
+    public func retargetUser(advertiserId: Int, segment: Int, completion: @escaping (Result<Void, AdzerkError>) -> Void) {
+        pixelRequest(endpoint: "rt/\(advertiserId)/\(segment)/i.gif", completion: completion)
+    }
+    
+    private func pixelRequest(endpoint: String, params: [String: String] = [:], completion: @escaping (Result<Void, AdzerkError>) -> Void) {
         guard let userKey = keyStore.currentUserKey else {
             logger.log(.warning, message: "WARNING: No userKey specified, and none can be found in the configured key store.")
             transport.callbackQueue.async {
@@ -97,8 +109,10 @@ public class UserDB {
         }
         
         guard let url = baseURL
-            .appendingPathComponent("optOut/i.gif")
-                .appendingQueryParameters(["userKey": userKey]) else {
+            .appendingPathComponent(endpoint)
+                .appendingQueryParameters(
+                    params.merging(["userKey": userKey], uniquingKeysWith: { $1 })
+                ) else {
             logger.log(.warning, message: "WARNING: unable to construct readUser URL")
             transport.callbackQueue.async {
                 completion(.failure(.errorPreparingRequest(nil)))

--- a/Tests/AdzerkSDKTests/DecisionSDKTests.swift
+++ b/Tests/AdzerkSDKTests/DecisionSDKTests.swift
@@ -142,7 +142,7 @@ final class DecisionSDKTests: XCTestCase {
             exp.fulfill()
             if let user = result.getOrFail() {
                 XCTAssertEqual(user.key, "ue1-e397eb5990")
-                XCTAssertEqual(user.interests, ["Sports"])
+                XCTAssertTrue(user.interests.contains("Sports"))
                 XCTAssertEqual(user.blockedItems, [
                         "advertisers": .array([]),
                         "campaigns": .array([]),
@@ -150,7 +150,6 @@ final class DecisionSDKTests: XCTestCase {
                         "flights": .array([]),
                     ]
                 )
-                XCTAssertEqual(user.custom, [:])
             }
         }
         waitForExpectations(timeout: 5, handler: nil)
@@ -193,6 +192,30 @@ final class DecisionSDKTests: XCTestCase {
             XCTAssertTrue(fakeKeyStore.currentUserKey != nil, "User key was not set")
         }
         waitForExpectations(timeout: 3.0, handler: nil)
+    }
+    
+    func testCanAddUserInterest() {
+        let userKey = "ue1-e397eb5990"
+        fakeKeyStore.save(userKey: userKey)
+
+        let exp = expectation(description: "API response received")
+        sdk.userDB().addInterest("cats") { result in
+            exp.fulfill()
+            result.getOrFail()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func testCanRetargetUser() {
+        let userKey = "ue1-e397eb5990"
+        fakeKeyStore.save(userKey: userKey)
+
+        let exp = expectation(description: "API response received")
+        sdk.userDB().retargetUser(segment: 1) { result in
+            exp.fulfill()
+            result.getOrFail()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     // Assert that the API response is called and returns .Success


### PR DESCRIPTION
Marking this as draft for now until #25 is merged, as it builds on that work.

This adds `addInterest` and `retarget` to `UserDB` and refactors those into a common `pixelRequest` method.