### PR TITLE
Fixes for several ad request and doc sample bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ DerivedData
 _source
 docsets
 .build
+
+.swiftpm/
+*.xcworkspace/

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ that contains the decisions for each placement requested.
 Consent preferences can be specified when building a request. For example, to set GDPR consent for tracking in the European Union (this defaults to false):
 
 ```swift
-let options = PlacementRequest<Placement>.Options()
+let options = PlacementRequest<StandardPlacement>.Options()
 options.consent = Consent(gdpr: false)
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ that contains the decisions for each placement requested.
 Consent preferences can be specified when building a request. For example, to set GDPR consent for tracking in the European Union (this defaults to false):
 
 ```swift
-let options = PlacementRequest<StandardPlacement>.Options()
+var options = PlacementRequest<StandardPlacement>.Options()
 options.consent = Consent(gdpr: false)
 ```
 

--- a/Sources/AdzerkSDK/DecisionSDK.swift
+++ b/Sources/AdzerkSDK/DecisionSDK.swift
@@ -20,7 +20,7 @@ public class DecisionSDK {
     */
     public static var defaultSiteId: Int?
     
-    static var logger = Logger()
+    public static var logger = Logger()
     
     /** The base URL template to use for API requests. {subdomain} must be replaced in this template string before use. */
     private static let AdzerkHostnameTemplate = "{subdomain}.adzerk.net"

--- a/Sources/AdzerkSDK/Logger.swift
+++ b/Sources/AdzerkSDK/Logger.swift
@@ -12,7 +12,7 @@ public struct Logger {
         }
     }
     
-    var level: Level = .info
+    public var level: Level = .info
     let destination: LogDestination
     
     public init(destination: LogDestination = OSLogDestination()) {

--- a/Sources/AdzerkSDK/Placement.swift
+++ b/Sources/AdzerkSDK/Placement.swift
@@ -61,13 +61,13 @@ public class StandardPlacement: Placement {
     public let count: Int?
     
     /** An array of integers representing the ad types to request. The full list can be found at https://github.com/adzerk/adzerk-api/wiki/Ad-Types . */
-    let adTypes: [Int]
+    public let adTypes: [Int]
     
-    var zoneIds: [Int]?
-    var eventIds: [Int]?
-    var campaignId: Int?
-    var flightId: Int?
-    var adId: Int?
+    public var zoneIds: [Int]?
+    public var eventIds: [Int]?
+    public var campaignId: Int?
+    public var flightId: Int?
+    public var adId: Int?
     
     public convenience init(divName: String, adTypes: [Int], count: Int? = nil) {
         guard let networkId = DecisionSDK.defaultNetworkId,

--- a/Sources/AdzerkSDK/Placement.swift
+++ b/Sources/AdzerkSDK/Placement.swift
@@ -94,10 +94,10 @@ public class StandardPlacement: Placement {
 
 /// Use this placement type if you need to pass additional options.
 public class CustomPlacement: StandardPlacement {
-    var additionalOptions: [String: AnyCodable] = [:]
+    public var properties: [String: AnyCodable] = [:]
     
     enum CodingKeys: String, CodingKey {
-        case additionalOptions
+        case properties
     }
     
     public override init(networkId: Int, siteId: Int, divName: String, adTypes: [Int], count: Int?) {
@@ -107,12 +107,12 @@ public class CustomPlacement: StandardPlacement {
     public override func encode(to encoder: Encoder) throws {
         try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(additionalOptions, forKey: .additionalOptions)
+        try container.encode(properties, forKey: .properties)
     }
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        additionalOptions = try container.decode([String: AnyCodable].self, forKey: .additionalOptions)
+        properties = try container.decode([String: AnyCodable].self, forKey: .properties)
         try super.init(from: decoder)
     }
 }

--- a/Sources/AdzerkSDK/PlacementRequest.swift
+++ b/Sources/AdzerkSDK/PlacementRequest.swift
@@ -27,6 +27,15 @@ public struct PlacementRequest<P: Placement>: Codable {
          parameters before they are added to the SDK.
          */
         public var additionalOptions: [String: AnyCodable]?
+        
+        public init(userKey: String? = nil, keywords: [String]? = nil, blockedCreatives: [Int]? = nil, flightViewTimes: [String: [Int]]? = nil, url: String? = nil, enableBotFiltering: Bool = false) {
+            self.userKey = userKey
+            self.keywords = keywords
+            self.blockedCreatives = blockedCreatives
+            self.flightViewTimes = flightViewTimes
+            self.url = url
+            self.enableBotFiltering = enableBotFiltering
+        }
     }
     
     let placements: [P]

--- a/Tests/AdzerkSDKTests/DecisionSDKTests.swift
+++ b/Tests/AdzerkSDKTests/DecisionSDKTests.swift
@@ -51,11 +51,11 @@ final class DecisionSDKTests: XCTestCase {
         waitForExpectations(timeout: 3.0, handler: nil)
     }
     
-    func testCanRequestCustomPlacementwithAdditionalOptions() {
+    func testCanRequestCustomPlacementwithCustomProperties() {
         let placement = Placements.custom(divName: "div1", adTypes: [5])
         placement.flightId = 699801
         placement.zoneIds = [136961]
-        placement.additionalOptions = [
+        placement.properties = [
             "custom_key": .string("custom_value"),
             "foos": .array([.string("bar"), .string("baz"), .string("quux")]),
             "minions": .dictionary([
@@ -118,7 +118,7 @@ final class DecisionSDKTests: XCTestCase {
         placement.campaignId = 1
         placement.flightId = 1
         placement.eventIds = [123]
-        placement.additionalOptions = ["key": .string("val")]
+        placement.properties = ["key": .string("val")]
         
         var options = placement.options()
         options.flightViewTimes = ["1234": [1512512, 1241212]]

--- a/Tests/AdzerkSDKTests/DecisionSDKTests.swift
+++ b/Tests/AdzerkSDKTests/DecisionSDKTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import AdzerkSDK
 
 final class DecisionSDKTests: XCTestCase {
-    private let networkId = 23
+    private let networkId = 9792
     private let siteId = 306998
     private var sdk: DecisionSDK!
     private var fakeKeyStore: UserKeyStore!
@@ -18,7 +18,7 @@ final class DecisionSDKTests: XCTestCase {
     }
 
     func testDefaultNetworkId() {
-        XCTAssertEqual(23, DecisionSDK.defaultNetworkId)
+        XCTAssertEqual(9792, DecisionSDK.defaultNetworkId)
     }
     
     func testDefaultSiteId() {

--- a/Tests/AdzerkSDKTests/DecisionSDKTests.swift
+++ b/Tests/AdzerkSDKTests/DecisionSDKTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AdzerkSDK
+import AdzerkSDK
 
 final class DecisionSDKTests: XCTestCase {
     private let networkId = 9792

--- a/Tests/AdzerkSDKTests/PlacementTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import XCTest
-@testable import AdzerkSDK
+import AdzerkSDK
 
 class PlacementTests: XCTestCase {
     

--- a/Tests/AdzerkSDKTests/PlacementTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementTests.swift
@@ -45,7 +45,7 @@ class PlacementTests: XCTestCase {
           "adTypes" : [
             5
           ],
-          "networkId" : 23,
+          "networkId" : 9792,
           "divName" : "someDiv",
           "zoneIds" : [
             136961
@@ -93,7 +93,7 @@ class PlacementTests: XCTestCase {
             5
           ],
           "divName" : "someDiv",
-          "networkId" : 23,
+          "networkId" : 9792,
           "siteId" : 306998,
           "zoneIds" : [
             136961

--- a/Tests/AdzerkSDKTests/PlacementTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementTests.swift
@@ -20,7 +20,7 @@ class PlacementTests: XCTestCase {
         }
     }
     
-    private let networkId = 23
+    private let networkId = 9792
     private let siteId = 306998
     
     override func setUp() {

--- a/Tests/AdzerkSDKTests/PlacementTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementTests.swift
@@ -67,7 +67,7 @@ class PlacementTests: XCTestCase {
     
     func testSerializeCustomPlacementWithAdditionalOptions() throws {
         let placement = Placements.custom(divName: "someDiv", adTypes: [5])
-        placement.additionalOptions = [
+        placement.properties = [
             "color": .string("blue"),
             "age": .int(57),
             "balance": .float(100.0),
@@ -83,17 +83,17 @@ class PlacementTests: XCTestCase {
 
         let expected = """
         {
-          "additionalOptions" : {
-            "age" : 57,
-            "balance" : 100,
-            "color" : "blue",
-            "powerUser" : true
-          },
           "adTypes" : [
             5
           ],
           "divName" : "someDiv",
           "networkId" : 9792,
+          "properties" : {
+            "age" : 57,
+            "balance" : 100,
+            "color" : "blue",
+            "powerUser" : true
+          },
           "siteId" : 306998,
           "zoneIds" : [
             136961


### PR DESCRIPTION
Note this PR solves the following internal Kevel Clubhouse cards:
- 18395: iOS SDK 2.0: Cannot pass keywords or UserDB ID on ad request
- 18396: iOS SDK 2.0: Cannot pass custom properties on ad placement
- 18397: iOS SDK 2.0: cannot set logging level
- 18400: iOS SDK 2.0: setting consent code sample doesn't work
- 18401: iOS SDK 2.0: tests using cross-wired site & network IDs