### PR TITLE
Fix reported version

### DIFF
--- a/Sources/AdzerkSDK/DecisionSDK-Version.swift
+++ b/Sources/AdzerkSDK/DecisionSDK-Version.swift
@@ -1,0 +1,1 @@
+let AdzerkDecisionSDKVersionString = "2.0.2"

--- a/Sources/AdzerkSDK/DecisionSDK.swift
+++ b/Sources/AdzerkSDK/DecisionSDK.swift
@@ -3,11 +3,7 @@ import Foundation
 /// Represents the interface for making requests against the Adzerk Decision API
 public class DecisionSDK {
     
-    static var SDKVersion: String {
-        let packageBundle = Bundle(for: Self.self)
-        let bundleVersion = packageBundle.infoDictionary?["CFBundleShortVersionString"] as? String
-        return bundleVersion ?? "?"
-    }
+    public static var SDKVersion = AdzerkDecisionSDKVersionString
     
     /** Provides storage for the default network ID to be used with all placement requests. If a value is present here,
     each placement request does not need to provide it.  Any value in the placement request will override this value.

--- a/Sources/AdzerkSDK/UserKeyStoreKeychain.swift
+++ b/Sources/AdzerkSDK/UserKeyStoreKeychain.swift
@@ -36,7 +36,10 @@ public class UserKeyStoreKeychain : UserKeyStore {
     */
     public func save(userKey: String) {
         let data = userKey.data(using: .utf8, allowLossyConversion: false)!
-        _ = KeychainHelper.save(userKeychainKey, data: data)
+        let result = KeychainHelper.save(userKeychainKey, data: data)
+        if !result {
+            print("Warning: saving user key failed")
+        }
     }
     
     /**


### PR DESCRIPTION
Previously we read the version dynamically from the Info.plist, but now that
the Xcode project is generated, this value gets reset.

This change extracts the version value into a definition Swift file that can be
later generated with scripting to keep this version consistent between
releases.

For now we can update this file manually until a script to automate releases for
a given version can be created.

Resolves #37