### PR TITLE
Catch up `PlacementDecision` with the decision API spec

### DIFF
--- a/Sources/AdzerkSDK/GeoPoint.swift
+++ b/Sources/AdzerkSDK/GeoPoint.swift
@@ -11,25 +11,37 @@ import Foundation
 public struct GeoPoint: Codable {
     public let lat: Double
     public let lon: Double
-    
+
     enum CodingKeys: String, CodingKey {
         case lat
         case lon
     }
-    
-    // the actual transport type gives us a string, so we want to convert that to/from a double with a custom encode/decode implementation
+
+    public init(lat: Double, lon: Double) {
+        self.lat = lat
+        self.lon = lon
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let latString = try container.decode(String.self, forKey: .lat)
-        let lonString = try container.decode(String.self, forKey: .lon)
-        
-        lat = Double(latString) ?? 0
-        lon = Double(lonString) ?? 0
+        lat = try container.decodeCoordinate(forKey: .lat)
+        lon = try container.decodeCoordinate(forKey: .lon)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(String(lat), forKey: .lat)
-        try container.encode(String(lon), forKey: .lon)
+        try container.encode(lat, forKey: .lat)
+        try container.encode(lon, forKey: .lon)
+    }
+}
+
+private extension KeyedDecodingContainer where Key == GeoPoint.CodingKeys {
+    /** The transport type is a number, but responses used to carry these as strings,
+        so both are accepted. */
+    func decodeCoordinate(forKey key: Key) throws -> Double {
+        if let value = try? decode(Double.self, forKey: key) {
+            return value
+        }
+        return Double(try decode(String.self, forKey: key)) ?? 0
     }
 }

--- a/Sources/AdzerkSDK/PlacementDecision.swift
+++ b/Sources/AdzerkSDK/PlacementDecision.swift
@@ -27,6 +27,16 @@ public struct PlacementDecision: Codable {
     public let clickUrl: URL?
     public let impressionUrl: URL?
     
+    /** The dimensions of the selected ad, if the creative supplies them. */
+    public let height: Int?
+    public let width: Int?
+
+    /** Custom metadata configured on the ad, only present if set. */
+    public let externalMetadata: [String: AnyCodable]?
+
+    /** Only present if the matched impression has an ecpmPartition set. */
+    public let ecpmPartition: String?
+
     /** An array of `PlacementDecision.Content` values, representing the actual contents
         to display for this decision, if there are any.
         */
@@ -36,6 +46,10 @@ public struct PlacementDecision: Codable {
         if there are any. */
     public let events: [Event]
     
+    /** When multiple ads are selected for a non-multi-winner placement, the additional
+        ads beyond the first are included here. */
+    public let adChain: [PlacementDecision]?
+
     /** All of the attributes will be present in this dictionary,
         in case there are additional attributes being sent that are not modeled
         as properties.
@@ -54,8 +68,13 @@ public struct PlacementDecision: Codable {
         case advertiserId
         case clickUrl
         case impressionUrl
+        case height
+        case width
+        case externalMetadata
+        case ecpmPartition
         case contents
         case events
+        case adChain
         case matchedPoints
     }
     
@@ -69,8 +88,13 @@ public struct PlacementDecision: Codable {
         try container.encode(advertiserId, forKey: .advertiserId)
         try container.encode(clickUrl, forKey: .clickUrl)
         try container.encode(impressionUrl, forKey: .impressionUrl)
+        try container.encodeIfPresent(height, forKey: .height)
+        try container.encodeIfPresent(width, forKey: .width)
+        try container.encodeIfPresent(externalMetadata, forKey: .externalMetadata)
+        try container.encodeIfPresent(ecpmPartition, forKey: .ecpmPartition)
         try container.encode(contents, forKey: .contents)
         try container.encode(events, forKey: .events)
+        try container.encodeIfPresent(adChain, forKey: .adChain)
         try container.encodeIfPresent(matchedPoints, forKey: .matchedPoints)
     }
     
@@ -92,8 +116,13 @@ public struct PlacementDecision: Codable {
         advertiserId = try container.decodeIfPresent(Int.self, forKey: .advertiserId)
         clickUrl = try container.decodeIfPresent(URL.self, forKey: .clickUrl)
         impressionUrl = try container.decodeIfPresent(URL.self, forKey: .impressionUrl)
+        height = try container.decodeIfPresent(Int.self, forKey: .height)
+        width = try container.decodeIfPresent(Int.self, forKey: .width)
+        externalMetadata = try container.decodeIfPresent([String: AnyCodable].self, forKey: .externalMetadata)
+        ecpmPartition = try container.decodeIfPresent(String.self, forKey: .ecpmPartition)
         contents = try container.decode([Content].self, forKey: .contents)
         events = try container.decode([Event].self, forKey: .events)
+        adChain = try container.decodeIfPresent([PlacementDecision].self, forKey: .adChain)
         matchedPoints = try container.decodeIfPresent([GeoPoint].self, forKey: .matchedPoints)
         
         allAttributes = try decoder.decodeAnyCodableTree(using: DynamicCodingKey.self)

--- a/Sources/AdzerkSDK/PlacementDecision.swift
+++ b/Sources/AdzerkSDK/PlacementDecision.swift
@@ -58,7 +58,10 @@ public struct PlacementDecision: Codable {
     
     /** If the request was made with includeMatchedPoints=true, then the response will contain an array of lat/lon GeoPoints that can be used for GeoDistance targeting. */
     public let matchedPoints: [GeoPoint]?
-    
+
+    /** If the request was made with includePricingData=true, then the response will contain the pricing details for this decision. */
+    public let pricing: PricingData?
+
     enum CodingKeys: String, CodingKey {
         case divName
         case adId
@@ -76,6 +79,7 @@ public struct PlacementDecision: Codable {
         case events
         case adChain
         case matchedPoints
+        case pricing
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -96,6 +100,7 @@ public struct PlacementDecision: Codable {
         try container.encode(events, forKey: .events)
         try container.encodeIfPresent(adChain, forKey: .adChain)
         try container.encodeIfPresent(matchedPoints, forKey: .matchedPoints)
+        try container.encodeIfPresent(pricing, forKey: .pricing)
     }
     
     public init(from decoder: Decoder) throws {
@@ -124,6 +129,7 @@ public struct PlacementDecision: Codable {
         events = try container.decode([Event].self, forKey: .events)
         adChain = try container.decodeIfPresent([PlacementDecision].self, forKey: .adChain)
         matchedPoints = try container.decodeIfPresent([GeoPoint].self, forKey: .matchedPoints)
+        pricing = try container.decodeIfPresent(PricingData.self, forKey: .pricing)
         
         allAttributes = try decoder.decodeAnyCodableTree(using: DynamicCodingKey.self)
     }

--- a/Sources/AdzerkSDK/PlacementPricing.swift
+++ b/Sources/AdzerkSDK/PlacementPricing.swift
@@ -1,0 +1,25 @@
+//
+//  PlacementPricing.swift
+//  AdzerkSDK
+//
+
+import Foundation
+
+/// Pricing details for a decision. Only present when the request sets `includePricingData` to true.
+public extension PlacementDecision {
+    struct PricingData: Codable {
+        public let price: Double?
+        public let clearPrice: Double?
+
+        /// Only present when a bid modifier applied to the impression.
+        public let modifiedPrice: Double?
+
+        /// Only present when the flight has a targetROAS configured.
+        public let optimizedPrice: Double?
+
+        public let eventMultiplier: Double?
+        public let revenue: Double?
+        public let rateType: Int?
+        public let eCPM: Double?
+    }
+}

--- a/Tests/AdzerkSDKTests/PlacementResponseTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementResponseTests.swift
@@ -79,20 +79,35 @@ class PlacementResponseTests: XCTestCase {
         XCTAssertNil(decision.ecpmPartition)
         XCTAssertNil(decision.adChain)
         XCTAssertNil(decision.matchedPoints)
+        XCTAssertNil(decision.pricing)
     }
 
-    /// Pricing fields are not modeled as properties, but remain reachable via `allAttributes`.
-    func testPricingIsAvailableInAllAttributes() throws {
+    func testDecodesPricingData() throws {
         let response = try decode(Self.responseWithNewFields)
         let decision = try XCTUnwrap(response.decisions["div1"]?.first)
-        let pricing = try XCTUnwrap(decision.allAttributes?["pricing"])
+        let pricing = try XCTUnwrap(decision.pricing)
 
-        guard case let .dictionary(values) = pricing else {
-            return XCTFail("expected pricing to decode as a dictionary, got \(pricing)")
-        }
-        XCTAssertEqual(values["modifiedPrice"], AnyCodable.float(1.5))
-        XCTAssertEqual(values["optimizedPrice"], AnyCodable.float(2.25))
-        XCTAssertEqual(values["eventMultiplier"], AnyCodable.float(1.1))
+        XCTAssertEqual(pricing.price, 3.0)
+        XCTAssertEqual(pricing.clearPrice, 2.0)
+        XCTAssertEqual(pricing.modifiedPrice, 1.5)
+        XCTAssertEqual(pricing.optimizedPrice, 2.25)
+        XCTAssertEqual(pricing.eventMultiplier, 1.1)
+        XCTAssertEqual(pricing.revenue, 0.003)
+        XCTAssertEqual(pricing.rateType, 2)
+        XCTAssertEqual(pricing.eCPM, 3.0)
+    }
+
+    /// Individual pricing fields are only sent when they apply to the matched impression.
+    func testDecodesPartialPricingData() throws {
+        let response = try decode(Self.responseWithPartialPricing)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+        let pricing = try XCTUnwrap(decision.pricing)
+
+        XCTAssertEqual(pricing.price, 3.0)
+        XCTAssertEqual(pricing.clearPrice, 2.0)
+        XCTAssertNil(pricing.modifiedPrice)
+        XCTAssertNil(pricing.optimizedPrice)
+        XCTAssertNil(pricing.eventMultiplier)
     }
 
     func testEncodesMatchedPointsAsNumbers() throws {
@@ -147,6 +162,19 @@ class PlacementResponseTests: XCTestCase {
             "rateType": 2,
             "eCPM": 3.0
           }
+        }
+      }
+    }
+    """
+
+    private static let responseWithPartialPricing = """
+    {
+      "decisions": {
+        "div1": {
+          "adId": 111,
+          "contents": [],
+          "events": [],
+          "pricing": { "price": 3.0, "clearPrice": 2.0, "revenue": 0.003, "rateType": 2, "eCPM": 3.0 }
         }
       }
     }

--- a/Tests/AdzerkSDKTests/PlacementResponseTests.swift
+++ b/Tests/AdzerkSDKTests/PlacementResponseTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import XCTest
+@testable import AdzerkSDK
+
+class PlacementResponseTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> PlacementResponse {
+        try AdzerkJSONDecoder().decode(PlacementResponse.self, from: Data(json.utf8))
+    }
+
+    func testDecodesDimensions() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+
+        XCTAssertEqual(decision.height, 250)
+        XCTAssertEqual(decision.width, 300)
+    }
+
+    func testDecodesExternalMetadata() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+
+        let metadata = try XCTUnwrap(decision.externalMetadata)
+        XCTAssertEqual(metadata["campaignTag"], AnyCodable.string("summer-sale"))
+        XCTAssertEqual(metadata["priority"], AnyCodable.int(3))
+    }
+
+    func testDecodesEcpmPartition() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+
+        XCTAssertEqual(decision.ecpmPartition, "partition-a")
+    }
+
+    func testDecodesAdChain() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+        let adChain = try XCTUnwrap(decision.adChain)
+
+        XCTAssertEqual(adChain.count, 1)
+        XCTAssertEqual(adChain[0].adId, 222)
+        XCTAssertEqual(adChain[0].creativeId, 223)
+
+        // nested decisions carry no divName of their own, so they inherit the placement's
+        XCTAssertEqual(adChain[0].divName, "div1")
+    }
+
+    func testDecodesNumericMatchedPoints() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+        let matchedPoints = try XCTUnwrap(decision.matchedPoints)
+
+        XCTAssertEqual(matchedPoints.count, 2)
+        XCTAssertEqual(matchedPoints[0].lat, 35.995063, accuracy: 0.000001)
+        XCTAssertEqual(matchedPoints[0].lon, -78.908187, accuracy: 0.000001)
+        XCTAssertEqual(matchedPoints[1].lat, 40.689188, accuracy: 0.000001)
+        XCTAssertEqual(matchedPoints[1].lon, -74.044562, accuracy: 0.000001)
+    }
+
+    /// Responses used to carry lat/lon as strings, so those are still accepted.
+    func testDecodesStringMatchedPoints() throws {
+        let response = try decode(Self.responseWithStringMatchedPoints)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+        let matchedPoints = try XCTUnwrap(decision.matchedPoints)
+
+        XCTAssertEqual(matchedPoints.count, 1)
+        XCTAssertEqual(matchedPoints[0].lat, 35.995063, accuracy: 0.000001)
+        XCTAssertEqual(matchedPoints[0].lon, -78.908187, accuracy: 0.000001)
+    }
+
+    func testDecodesResponseWithoutOptionalFields() throws {
+        let response = try decode(Self.minimalResponse)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+
+        XCTAssertEqual(decision.adId, 111)
+        XCTAssertNil(decision.height)
+        XCTAssertNil(decision.width)
+        XCTAssertNil(decision.externalMetadata)
+        XCTAssertNil(decision.ecpmPartition)
+        XCTAssertNil(decision.adChain)
+        XCTAssertNil(decision.matchedPoints)
+    }
+
+    /// Pricing fields are not modeled as properties, but remain reachable via `allAttributes`.
+    func testPricingIsAvailableInAllAttributes() throws {
+        let response = try decode(Self.responseWithNewFields)
+        let decision = try XCTUnwrap(response.decisions["div1"]?.first)
+        let pricing = try XCTUnwrap(decision.allAttributes?["pricing"])
+
+        guard case let .dictionary(values) = pricing else {
+            return XCTFail("expected pricing to decode as a dictionary, got \(pricing)")
+        }
+        XCTAssertEqual(values["modifiedPrice"], AnyCodable.float(1.5))
+        XCTAssertEqual(values["optimizedPrice"], AnyCodable.float(2.25))
+        XCTAssertEqual(values["eventMultiplier"], AnyCodable.float(1.1))
+    }
+
+    func testEncodesMatchedPointsAsNumbers() throws {
+        let point = GeoPoint(lat: 35.995063, lon: -78.908187)
+        let data = try JSONEncoder().encode(point)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["lat"] as? Double, 35.995063)
+        XCTAssertEqual(json["lon"] as? Double, -78.908187)
+    }
+
+    private static let responseWithNewFields = """
+    {
+      "user": { "key": "abc-123" },
+      "decisions": {
+        "div1": {
+          "adId": 111,
+          "creativeId": 112,
+          "flightId": 113,
+          "campaignId": 114,
+          "advertiserId": 115,
+          "clickUrl": "https://e-9792.adzerk.net/r?e=click",
+          "impressionUrl": "https://e-9792.adzerk.net/i.gif",
+          "height": 250,
+          "width": 300,
+          "ecpmPartition": "partition-a",
+          "externalMetadata": {
+            "campaignTag": "summer-sale",
+            "priority": 3
+          },
+          "contents": [ { "type": "html", "template": "image", "body": "<div></div>" } ],
+          "events": [],
+          "adChain": [
+            {
+              "adId": 222,
+              "creativeId": 223,
+              "contents": [],
+              "events": []
+            }
+          ],
+          "matchedPoints": [
+            { "lat": 35.995063, "lon": -78.908187 },
+            { "lat": 40.689188, "lon": -74.044562 }
+          ],
+          "pricing": {
+            "price": 3.0,
+            "clearPrice": 2.0,
+            "modifiedPrice": 1.5,
+            "optimizedPrice": 2.25,
+            "eventMultiplier": 1.1,
+            "revenue": 0.003,
+            "rateType": 2,
+            "eCPM": 3.0
+          }
+        }
+      }
+    }
+    """
+
+    private static let responseWithStringMatchedPoints = """
+    {
+      "decisions": {
+        "div1": {
+          "adId": 111,
+          "contents": [],
+          "events": [],
+          "matchedPoints": [ { "lat": "35.995063", "lon": "-78.908187" } ]
+        }
+      }
+    }
+    """
+
+    private static let minimalResponse = """
+    {
+      "decisions": {
+        "div1": {
+          "adId": 111,
+          "contents": [],
+          "events": []
+        }
+      }
+    }
+    """
+}


### PR DESCRIPTION
Adds `height`, `width`, `externalMetadata`, `adChain`, `ecpmPartition`, and `pricing` to `PlacementDecision`.

Also fixes `GeoPoint`, which decoded lat/lon as `String` only — the spec now types them as numbers, so a numeric coordinate failed the entire response decode.